### PR TITLE
op-mode: T6695: Machine-readable operational mode support for traceroute

### DIFF
--- a/data/templates/https/nginx.default.j2
+++ b/data/templates/https/nginx.default.j2
@@ -48,7 +48,7 @@ server {
     ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
 
     # proxy settings for HTTP API, if enabled; 503, if not
-    location ~ ^/(retrieve|configure|config-file|image|import-pki|container-image|generate|show|reboot|reset|poweroff|docs|openapi.json|redoc|graphql) {
+    location ~ ^/(retrieve|configure|config-file|image|import-pki|container-image|generate|show|reboot|reset|poweroff|traceroute|docs|openapi.json|redoc|graphql) {
 {% if api is vyos_defined %}
         proxy_pass http://unix:/run/api.sock;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/op-mode-definitions/mtr.xml.in
+++ b/op-mode-definitions/mtr.xml.in
@@ -31,7 +31,7 @@
         <list>&lt;hostname&gt; &lt;x.x.x.x&gt; &lt;h:h:h:h:h:h:h:h&gt;</list>
       </completionHelp>
     </properties>
-    <command>${vyos_op_scripts_dir}/mtr.py ${@:2}</command>
+    <command>${vyos_op_scripts_dir}/mtr_execute.py mtr --host $2</command>
     <children>
       <leafNode name="node.tag">
         <properties>

--- a/python/vyos/configsession.py
+++ b/python/vyos/configsession.py
@@ -48,6 +48,8 @@ REBOOT = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'reboot']
 POWEROFF = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'poweroff']
 OP_CMD_ADD = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'add']
 OP_CMD_DELETE = ['/opt/vyatta/bin/vyatta-op-cmd-wrapper', 'delete']
+TRACEROUTE = ['/usr/libexec/vyos/op_mode/mtr_execute.py', 'mtr',
+              '--report-mode', '--report-cycles', '1', '--json', '--host']
 
 # Default "commit via" string
 APP = "vyos-http-api"
@@ -284,4 +286,8 @@ class ConfigSession(object):
 
     def show_container_image(self):
         out = self.__run_command(SHOW + ['container', 'image'])
+        return out
+
+    def traceroute(self, host):
+        out = self.__run_command(TRACEROUTE + [host])
         return out

--- a/python/vyos/opmode.py
+++ b/python/vyos/opmode.py
@@ -89,7 +89,7 @@ class InternalError(Error):
 
 
 def _is_op_mode_function_name(name):
-    if re.match(r"^(show|clear|reset|restart|add|update|delete|generate|set|renew|release|execute)", name):
+    if re.match(r"^(show|clear|reset|restart|add|update|delete|generate|set|renew|release|execute|mtr)", name):
         return True
     else:
         return False

--- a/src/op_mode/mtr.py
+++ b/src/op_mode/mtr.py
@@ -22,11 +22,21 @@ from vyos.utils.network import interface_list
 from vyos.utils.network import vrf_list
 from vyos.utils.process import call
 
+
+def protocol_list():
+    return ['tcp', 'udp', 'sctp']
+
 options = {
     'report': {
         'mtr': '{command} --report',
         'type': 'noarg',
         'help': 'This option puts mtr into report mode. When in this mode, mtr will run for the number of cycles specified by the -c option, and then print statistics and exit.'
+    },
+    'protocol': {
+        'mtr': '{command} --{value}',
+        'type': '<protocol>',
+        'helpfunction': protocol_list,
+        'help': 'Use UDP, TCP or SCTP  datagrams instead of ICMP ECHO.'
     },
     'report-wide': {
         'mtr': '{command} --report-wide',
@@ -128,21 +138,6 @@ options = {
         'mtr': '{command} --max-unknown {value}',
         'type': '<num>',
         'help': 'Specifies the maximum unknown host. Default is 5.'
-    },
-    'udp': {
-        'mtr': '{command} --udp',
-        'type': 'noarg',
-        'help': 'Use UDP datagrams instead of ICMP ECHO.'
-    },
-    'tcp': {
-        'mtr': '{command} --tcp',
-        'type': 'noarg',
-        'help': ' Use TCP SYN packets instead of ICMP ECHO. PACKETSIZE is ignored, since SYN packets can not contain data.'
-    },
-    'sctp': {
-        'mtr': '{command} --sctp',
-        'type': 'noarg',
-        'help': 'Use Stream Control Transmission Protocol packets instead of ICMP ECHO.'
     },
     'port': {
         'mtr': '{command} --port {value}',

--- a/src/op_mode/mtr_execute.py
+++ b/src/op_mode/mtr_execute.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+#
+# Copyright (C) 2024 VyOS maintainers and contributors
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2 or later as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import ipaddress
+import socket
+import sys
+import typing
+
+from vyos.utils.network import interface_list
+from vyos.utils.network import vrf_list
+from vyos.utils.process import cmd
+from vyos.utils.process import call
+
+import vyos.opmode
+
+ArgProtocol = typing.Literal['tcp', 'udp', 'sctp']
+noargs_list = ['report_mode', 'json', 'report_wide', 'split', 'raw', 'no_dns', 'aslookup']
+
+
+def vrf_list_default():
+    return vrf_list() + ['default']
+
+
+options = {
+    'report_mode': {
+        'mtr': '{command} --report',
+    },
+    'protocol': {
+        'mtr': '{command} --{value}',
+    },
+    'json': {
+        'mtr': '{command} --json',
+    },
+    'report_wide': {
+        'mtr': '{command} --report-wide',
+    },
+    'raw': {
+        'mtr': '{command} --raw',
+    },
+    'split': {
+        'mtr': '{command} --split',
+    },
+    'no_dns': {
+        'mtr': '{command} --no-dns',
+    },
+    'show_ips': {
+        'mtr': '{command} --show-ips {value}',
+    },
+    'ipinfo': {
+        'mtr': '{command} --ipinfo {value}',
+    },
+    'aslookup': {
+        'mtr': '{command} --aslookup',
+    },
+    'interval': {
+        'mtr': '{command} --interval {value}',
+    },
+    'report_cycles': {
+        'mtr': '{command} --report-cycles {value}',
+    },
+    'psize': {
+        'mtr': '{command} --psize {value}',
+    },
+    'bitpattern': {
+        'mtr': '{command} --bitpattern {value}',
+    },
+    'gracetime': {
+        'mtr': '{command} --gracetime {value}',
+    },
+    'tos': {
+        'mtr': '{command} --tos {value}',
+    },
+    'mpls': {
+        'mtr': '{command} --mpls {value}',
+    },
+    'interface': {
+        'mtr': '{command} --interface {value}',
+        'helpfunction': interface_list,
+    },
+    'address': {
+        'mtr': '{command} --address {value}',
+    },
+    'first_ttl': {
+        'mtr': '{command} --first-ttl {value}',
+    },
+    'max_ttl': {
+        'mtr': '{command} --max-ttl {value}',
+    },
+    'max_unknown': {
+        'mtr': '{command} --max-unknown {value}',
+    },
+    'port': {
+        'mtr': '{command} --port {value}',
+    },
+    'localport': {
+        'mtr': '{command} --localport {value}',
+    },
+    'timeout': {
+        'mtr': '{command} --timeout {value}',
+    },
+    'mark': {
+        'mtr': '{command} --mark {value}',
+    },
+    'vrf': {
+        'mtr': 'sudo ip vrf exec {value} {command}',
+        'helpfunction': vrf_list_default,
+        'dflt': 'default',
+    },
+}
+
+mtr_command = {
+    4: '/bin/mtr -4',
+    6: '/bin/mtr -6',
+}
+
+
+def mtr(
+    host: str,
+    report_mode: typing.Optional[bool],
+    protocol: typing.Optional[ArgProtocol],
+    report_wide: typing.Optional[bool],
+    raw: typing.Optional[bool],
+    json: typing.Optional[bool],
+    split: typing.Optional[bool],
+    no_dns: typing.Optional[bool],
+    show_ips: typing.Optional[str],
+    ipinfo: typing.Optional[str],
+    aslookup: typing.Optional[bool],
+    interval: typing.Optional[str],
+    report_cycles: typing.Optional[str],
+    psize: typing.Optional[str],
+    bitpattern: typing.Optional[str],
+    gracetime: typing.Optional[str],
+    tos: typing.Optional[str],
+    mpl: typing.Optional[bool],
+    interface: typing.Optional[str],
+    address: typing.Optional[str],
+    first_ttl: typing.Optional[str],
+    max_ttl: typing.Optional[str],
+    max_unknown: typing.Optional[str],
+    port: typing.Optional[str],
+    localport: typing.Optional[str],
+    timeout: typing.Optional[str],
+    mark: typing.Optional[str],
+    vrf: typing.Optional[str],
+):
+    args = locals()
+    for name, option in options.items():
+        if 'dflt' in option and not args[name]:
+            args[name] = option['dflt']
+
+    try:
+        ip = socket.gethostbyname(host)
+    except UnicodeError:
+        raise vyos.opmode.InternalError(f'Unknown host: {host}')
+    except socket.gaierror:
+        ip = host
+
+    try:
+        version = ipaddress.ip_address(ip).version
+    except ValueError:
+        raise vyos.opmode.InternalError(f'Unknown host: {host}')
+
+    command = mtr_command[version]
+
+    for key, val in args.items():
+        if key in options and val:
+            if 'helpfunction' in options[key]:
+                allowed_values = options[key]['helpfunction']()
+                if val not in allowed_values:
+                    raise vyos.opmode.InternalError(f'Invalid argument for option {key} - {val}')
+            value = '' if key in noargs_list else val
+            command = options[key]['mtr'].format(command=command, value=val)
+
+    if json:
+        output = cmd(f'{command} {host}')
+        print(output)
+    else:
+        call(f'{command} --curses --displaymode 0 {host}')
+
+
+if __name__ == '__main__':
+    try:
+        res = vyos.opmode.run(sys.modules[__name__])
+        if res:
+            print(res)
+    except (ValueError, vyos.opmode.Error) as e:
+        print(e)
+        sys.exit(1)

--- a/src/services/vyos-http-api-server
+++ b/src/services/vyos-http-api-server
@@ -307,6 +307,20 @@ class PoweroffModel(ApiModel):
         }
 
 
+class TracerouteModel(ApiModel):
+    op: StrictStr
+    host: StrictStr
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "key": "id_key",
+                "op": "traceroute",
+                "host": "host",
+            }
+        }
+
+
 class Success(BaseModel):
     success: bool
     data: Union[str, bool, Dict]
@@ -418,7 +432,7 @@ class MultipartRequest(Request):
                         self.form_err = (400,
                         f"Malformed command '{c}': missing 'op' field")
                     if endpoint not in ('/config-file', '/container-image',
-                                        '/image', '/configure-section'):
+                                        '/image', '/configure-section', '/traceroute'):
                         if 'path' not in c:
                             self.form_err = (400,
                             f"Malformed command '{c}': missing 'path' field")
@@ -888,6 +902,27 @@ def poweroff_op(data: PoweroffModel):
     try:
         if op == 'poweroff':
             res = session.poweroff(path)
+        else:
+            return error(400, f"'{op}' is not a valid operation")
+    except ConfigSessionError as e:
+        return error(400, str(e))
+    except Exception as e:
+        logger.critical(traceback.format_exc())
+        return error(500, "An internal error occured. Check the logs for details.")
+
+    return success(res)
+
+
+@app.post('/traceroute')
+def traceroute_op(data: TracerouteModel):
+    session = app.state.vyos_session
+
+    op = data.op
+    host = data.host
+
+    try:
+        if op == 'traceroute':
+            res = session.traceroute(host)
         else:
             return error(400, f"'{op}' is not a valid operation")
     except ConfigSessionError as e:


### PR DESCRIPTION
<!-- All PR should follow this template to allow a clean and transparent review -->
<!-- Text placed between these delimiters is considered a comment and is not rendered -->

## Change Summary
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!---
What types of changes does your code introduce? Put an 'x' in all the boxes that apply.
NOTE: Markdown requires no leading or trailing whitespace inside the [ ] for checking
the box, please use [x]
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes)
- [ ] Migration from an old Vyatta component to vyos-1x, please link to related PR inside obsoleted component
- [ ] Other (please describe):

## Related Task(s)
<!-- optional: Link to related other tasks on Phabricator. -->
<!-- * https://vyos.dev/Txxxx -->
* https://vyos.dev/T6695
## Related PR(s)
<!-- Link here any PRs in other repositories that are required by this PR -->

## Component(s) name
<!-- A rather incomplete list of components: ethernet, wireguard, bgp, mpls, ldp, l2tp, dhcp ... -->
op-mode
## Proposed changes
<!--- Describe your changes in detail -->

## How to test
<!---
Please describe in detail how you tested your changes. Include details of your testing
environment, and the tests you ran. When pasting configs, logs, shell output, backtraces,
and other large chunks of text, surround this text with triple backtics
```
like this
```
-->
```
vyos@vyos:~$ curl -k --location --request POST 'https://localhost/traceroute' --form data='{"op": "traceroute", "host": "192.0.2.1"}' --form key='foo'
{"success": true, "data": "{\n    \"report\": {\n        \"mtr\": {\n            \"src\": \"vyos\",\n            \"dst\": \"192.0.2.1\",\n            \"tos\": 0,\n            \"tests\": 1,\n            \"psize\": \"64\",\n            \"bitpattern\": \"0x00\"\n        },\n        \"hubs\": [\n            {\n                \"count\": 1,\n                \"host\": \"192.168.122.1\",\n                \"Loss%\": 0.0,\n                \"Snt\": 1,\n                \"Last\": 1.475,\n                \"Avg\": 1.475,\n                \"Best\": 1.475,\n                \"Wrst\": 1.475,\n                \"StDev\": 0.0\n            },\n            {\n                \"count\": 2,\n                \"host\": \"192.168.179.2\",\n                \"Loss%\": 0.0,\n                \"Snt\": 1,\n                \"Last\": 2.383,\n                \"Avg\": 2.383,\n                \"Best\": 2.383,\n                \"Wrst\": 2.383,\n                \"StDev\": 0.0\n            },\n            {\n                \"count\": 3,\n                \"host\": \"???\",\n                \"Loss%\": 100.0,\n                \"Snt\": 1,\n                \"Last\": 0.0,\n                \"Avg\": 0.0,\n                \"Best\": 0.0,\n                \"Wrst\": 0.0,\n                \"StDev\": 0.0\n            }\n        ]\n    }\n}\n", "error": null}
```
## Smoketest result
<!-- Provide the output of the smoketest
```
$ /usr/libexec/vyos/tests/smoke/cli/test_xxx_feature.py
test_01_simple_options (__main__.TestFeature.test_01_simple_options) ... ok
```
-->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- The entire development process is outlined here: https://docs.vyos.io/en/latest/contributing/development.html -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/vyos/vyos-1x/blob/current/CONTRIBUTING.md) document
- [ ] I have linked this PR to one or more Phabricator Task(s)
- [ ] I have run the components [**SMOKETESTS**](https://github.com/vyos/vyos-1x/tree/current/smoketest/scripts/cli) if applicable
- [ ] My commit headlines contain a valid Task id
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
